### PR TITLE
12 mutex

### DIFF
--- a/src/main/eo/org/eolang/threads/mutex.eo
+++ b/src/main/eo/org/eolang/threads/mutex.eo
@@ -1,0 +1,29 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2022 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++architect 28lev11@gmail.com
++home https://github.com/objectionary/eo-threads
++package org.eolang.threads
++rt jvm org.eolang:eo-threads:0.0.0
++version 0.0.0
+
+[permits] > mutex

--- a/src/main/eo/org/eolang/threads/mutex.eo
+++ b/src/main/eo/org/eolang/threads/mutex.eo
@@ -27,14 +27,11 @@
 +version 0.0.0
 
 [permits] > mutex
-  [] > acquire
-    seq > @
-      QQ.io.stdout
-        "Acquires\n"
-      TRUE
+  [locks] > acquire
+    [] > @ /bool
 
-    [] > release
-      seq > @
-        QQ.io.stdout
-          "Releases\n"
-        TRUE
+    # @todo #12:90min We need to count numbers of locks
+    #  and releases in order to throw exceptions
+    #  if there were more releases then locks
+    [releases] > release
+      [] > @ /bool

--- a/src/main/eo/org/eolang/threads/mutex.eo
+++ b/src/main/eo/org/eolang/threads/mutex.eo
@@ -27,3 +27,14 @@
 +version 0.0.0
 
 [permits] > mutex
+  [] > acquire
+    seq > @
+      QQ.io.stdout
+        "Acquires\n"
+      TRUE
+
+    [] > release
+      seq > @
+        QQ.io.stdout
+          "Releases\n"
+        TRUE

--- a/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOrelease$EOφ.java
+++ b/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOrelease$EOφ.java
@@ -63,8 +63,8 @@ public class EOmutex$EOacquire$EOrelease$EOφ extends PhDefault {
                     final Phi mutex = rho.attr("ρ").get().attr("ρ").get().attr("ρ").get();
                     System.out.println("JAVA after mutex in release");
                     final long releases = new Dataized(
-                        rho.attr("ρ").get().attr("releases").get()).take(Long.class
-                    );
+                        rho.attr("ρ").get().attr("releases").get()
+                    ).take(Long.class);
                     final Semaphore semaphore = Semaphores.INSTANCE.get(mutex);
                     semaphore.release((int) releases);
                     System.out.println("JAVA release");

--- a/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOrelease$EOφ.java
+++ b/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOrelease$EOφ.java
@@ -59,15 +59,12 @@ public class EOmutex$EOacquire$EOrelease$EOφ extends PhDefault {
             new AtComposite(
                 this,
                 rho -> {
-                    System.out.println("JAVA before mutex in release");
                     final Phi mutex = rho.attr("ρ").get().attr("ρ").get().attr("ρ").get();
-                    System.out.println("JAVA after mutex in release");
                     final long releases = new Dataized(
                         rho.attr("ρ").get().attr("releases").get()
                     ).take(Long.class);
                     final Semaphore semaphore = Semaphores.INSTANCE.get(mutex);
                     semaphore.release((int) releases);
-                    System.out.println("JAVA release");
                     return new Data.ToPhi(true);
                 }
             )

--- a/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOrelease$EOφ.java
+++ b/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOrelease$EOφ.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * EO org.eolang.threads package.
+ *
+ * @since 0.0
+ * @checkstyle PackageNameCheck (4 lines)
+ */
+package EOorg.EOeolang.EOthreads;
+
+import java.util.concurrent.Semaphore;
+import org.eolang.AtComposite;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Release.
+ *
+ * @checkstyle TypeNameCheck (5 lines)
+ * @since 0.0
+ */
+@XmirObject(oname = "mutex.acquire.release.φ")
+public class EOmutex$EOacquire$EOrelease$EOφ extends PhDefault {
+
+    /**
+     * Ctor.
+     *
+     * @param sigma Sigma
+     */
+    public EOmutex$EOacquire$EOrelease$EOφ(final Phi sigma) {
+        super(sigma);
+        this.add(
+            "φ",
+            new AtComposite(
+                this,
+                rho -> {
+                    System.out.println("JAVA before mutex in release");
+                    final Phi mutex = rho.attr("ρ").get().attr("ρ").get().attr("ρ").get();
+                    System.out.println("JAVA after mutex in release");
+                    final long releases = new Dataized(
+                        rho.attr("ρ").get().attr("releases").get()).take(Long.class
+                    );
+                    final Semaphore semaphore = Semaphores.INSTANCE.get(mutex);
+                    semaphore.release((int) releases);
+                    System.out.println("JAVA release");
+                    return new Data.ToPhi(true);
+                }
+            )
+        );
+    }
+
+}

--- a/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOφ.java
+++ b/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOφ.java
@@ -64,7 +64,6 @@ public class EOmutex$EOacquire$EOφ extends PhDefault {
                         rho.attr("ρ").get().attr("locks").get()
                     ).take(Long.class);
                     final Semaphore semaphore = Semaphores.INSTANCE.get(mutex);
-                    System.out.println("Java acquires");
                     semaphore.acquire((int) locks);
                     return new Data.ToPhi(true);
                 }

--- a/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOφ.java
+++ b/src/main/java/EOorg/EOeolang/EOthreads/EOmutex$EOacquire$EOφ.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * EO org.eolang.threads package.
+ *
+ * @since 0.0
+ * @checkstyle PackageNameCheck (4 lines)
+ */
+package EOorg.EOeolang.EOthreads;
+
+import java.util.concurrent.Semaphore;
+import org.eolang.AtComposite;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.XmirObject;
+
+/**
+ * Acquire.
+ *
+ * @checkstyle TypeNameCheck (5 lines)
+ * @since 0.0
+ */
+@XmirObject(oname = "mutex.acquire.φ")
+public class EOmutex$EOacquire$EOφ extends PhDefault {
+
+    /**
+     * Ctor.
+     *
+     * @param sigma Sigma
+     */
+    public EOmutex$EOacquire$EOφ(final Phi sigma) {
+        super(sigma);
+        this.add(
+            "φ",
+            new AtComposite(
+                this,
+                rho -> {
+                    final Phi mutex = rho.attr("ρ").get().attr("ρ").get();
+                    final long locks = new Dataized(
+                        rho.attr("ρ").get().attr("locks").get()
+                    ).take(Long.class);
+                    final Semaphore semaphore = Semaphores.INSTANCE.get(mutex);
+                    System.out.println("Java acquires");
+                    semaphore.acquire((int) locks);
+                    return new Data.ToPhi(true);
+                }
+            )
+        );
+    }
+
+}

--- a/src/main/java/EOorg/EOeolang/EOthreads/Semaphores.java
+++ b/src/main/java/EOorg/EOeolang/EOthreads/Semaphores.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * EO org.eolang.threads package.
+ *
+ * @since 0.0
+ * @checkstyle PackageNameCheck (4 lines)
+ */
+package EOorg.EOeolang.EOthreads;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+
+/**
+ * All semaphores.
+ *
+ * @since 0.0
+ */
+public final class Semaphores {
+
+    /**
+     * Semaphores.
+     */
+    public static final Semaphores INSTANCE = new Semaphores();
+
+    /**
+     * All Semaphores.
+     * They are contained in a map with Phi mutexes as keys
+     */
+    private final ConcurrentHashMap<Phi, Semaphore> all =
+            new ConcurrentHashMap<>(0);
+
+    /**
+     * Ctor.
+     */
+    private Semaphores() {
+        // Singleton
+    }
+
+    /**
+     * Get.
+     *
+     * @param mutex Phi mutex as a key
+     * @return Semaphore matching to the key
+     */
+    public Semaphore get(final Phi mutex) {
+        return this.all.computeIfAbsent(
+            mutex,
+            key -> {
+                final long permits = new Dataized(key.attr("permits").get()).take(Long.class);
+                return new Semaphore((int) permits);
+            }
+        );
+    }
+}

--- a/src/main/java/EOorg/EOeolang/EOthreads/Semaphores.java
+++ b/src/main/java/EOorg/EOeolang/EOthreads/Semaphores.java
@@ -52,7 +52,7 @@ public final class Semaphores {
      * They are contained in a map with Phi mutexes as keys
      */
     private final ConcurrentHashMap<Phi, Semaphore> all =
-            new ConcurrentHashMap<>(0);
+        new ConcurrentHashMap<>(0);
 
     /**
      * Ctor.

--- a/src/test/eo/org/eolang/threads/mutex-test.eo
+++ b/src/test/eo/org/eolang/threads/mutex-test.eo
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2022 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.threads.mutex
++architect 28lev11@gmail.com
++home https://github.com/objectionary/eo-threads
++junit
++package org.eolang.threads
++version 0.0.0
+
+[] > acquire-release
+  mutex 100 > m
+  seq > @
+    m.acquire > a
+    a.release

--- a/src/test/eo/org/eolang/threads/mutex-test.eo
+++ b/src/test/eo/org/eolang/threads/mutex-test.eo
@@ -82,7 +82,7 @@
       mem
       6
 
-# @todo #12:90min Implement teet of mutex
+# @todo #12:90min Implement test of mutex
 #  with 2 threads that acquires mutex,
 #  sleep and then releas. So in fact
 #  they must sleep in series, not parallely.

--- a/src/test/eo/org/eolang/threads/mutex-test.eo
+++ b/src/test/eo/org/eolang/threads/mutex-test.eo
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 +alias org.eolang.threads.mutex
++alias org.eolang.threads.thread
 +architect 28lev11@gmail.com
 +home https://github.com/objectionary/eo-threads
 +junit
@@ -30,5 +31,61 @@
 [] > acquire-release
   mutex 100 > m
   seq > @
-    m.acquire > a
+    m.acquire 1 > a
     a.release
+      1
+    m.acquire 1 > b
+    b.release
+      1
+
+[] > double-acquire
+  mutex 2 > m
+  seq > @
+    m.acquire > a
+      1
+    m.acquire > b
+      1
+    a.release
+      1
+    b.release
+      1
+
+[] > acquire-with-locks
+  mutex 100 > m
+  seq > @
+    m.acquire > a
+      100
+    a.release
+      50
+    a.release
+      50
+
+[] > lock-with-threads
+  memory 1 > mem
+  mutex 1 > mut
+  [x] > multiple-by-x
+    seq > @
+      mut.acquire 1 > a
+      mem.write
+        mem.times x
+      a.release 1
+  thread > t1
+    multiple-by-x 2
+  thread > t2
+    multiple-by-x 3
+  seq > @
+    t1.start
+    t2.start
+    t1.join
+    t2.join
+    eq.
+      mem
+      6
+
+# @todo #12:90min Implement teet of mutex
+#  with 2 threads that acquires mutex,
+#  sleep and then releas. So in fact
+#  they must sleep in series, not parallely.
+#  You can do it when sys-call will be released.
+[] > test-with-time
+  nop > @


### PR DESCRIPTION
@Graur please review
I implemented a main part of `mutex`. After this pr we need only to count locks with releases and throw `ExFailure` where we must.
In the issue #31  a little bit changed how to use `mutex`: `mutex.acquire` and `mutex.release` have a free attribute. 