### PR TITLE
16 time of day test

### DIFF
--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -116,9 +116,9 @@
 
 [] > parallel-sleep
   thread > t1
-    sleep 200
+    sleep 300
   thread > t2
-    sleep 200
+    sleep 300
   memory 0 > start
   memory 0 > finish
   if. > @
@@ -136,5 +136,5 @@
           call "gettimeofday"
         lt.
           finish.minus start
-          400000
+          600000
       $.equal-to TRUE

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -94,6 +94,26 @@
     $.equal-to
       "The 1th argument of 'int.div' is invalid: division by zero is infinity"
 
+[] > gettimeofday-returns-in-nanos
+  memory 0 > start
+  memory 0 > finish
+  if. > @
+    QQ.sys.uname.is-windows
+    nop
+    assert-that
+      seq
+        start.write
+          call "gettimeofday"
+        sleep 200
+        finish.write
+          call "gettimeofday"
+        finish.minus start
+      $.all-of
+        $.less-than
+          300000
+        $.greater-than
+          100000
+
 [] > parallel-sleep
   thread > t1
     sleep 200

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 +alias org.eolang.hamcrest.assert-that
++alias org.eolang.sys.call
 +alias org.eolang.threads.thread
 +alias org.eolang.threads.sleep
 +architect 28lev11@gmail.com
@@ -93,31 +94,24 @@
     $.equal-to
       "The 1th argument of 'int.div' is invalid: division by zero is infinity"
 
-[] > parallel-sleeping
+[] > parallel-sleep
   thread > t1
     sleep 200
   thread > t2
     sleep 200
-  seq > @
-    QQ.sys.call > start
-      "gettimeofday"
-    t1.start
-    t2.start
-    t1.join
-    t2.join
-    QQ.sys.call > finish
-      "gettimeofday"
-    lte.
-      minus.
-        finish
-        start
-      300
-
-[] > get-time-of-day-test
-  if. > @
-    QQ.sys.uname.is-windows
-    nop
-    assert-that
-      QQ.sys.call
-        "gettimeofday"
-      $.greater-than 0
+  memory 0 > start
+  memory 0 > finish
+  assert-that > @
+    seq
+      start.write
+        call "gettimeofday"
+      t1.start
+      t2.start
+      t1.join
+      t2.join
+      finish.write
+        call "gettimeofday"
+      lt.
+        finish.minus start
+        300000
+    $.equal-to TRUE

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -110,7 +110,7 @@
         finish.minus start
       $.all-of
         $.less-than
-          300000
+          1000000
         $.greater-than
           100000
 

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -101,17 +101,20 @@
     sleep 200
   memory 0 > start
   memory 0 > finish
-  assert-that > @
-    seq
-      start.write
-        call "gettimeofday"
-      t1.start
-      t2.start
-      t1.join
-      t2.join
-      finish.write
-        call "gettimeofday"
-      lt.
-        finish.minus start
-        390000
-    $.equal-to TRUE
+  if. > @
+    QQ.sys.uname.is-windows
+    nop
+    assert-that
+      seq
+        start.write
+          call "gettimeofday"
+        t1.start
+        t2.start
+        t1.join
+        t2.join
+        finish.write
+          call "gettimeofday"
+        lt.
+          finish.minus start
+          400000
+      $.equal-to TRUE

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -22,6 +22,7 @@
 
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.threads.thread
++alias org.eolang.threads.sleep
 +architect 28lev11@gmail.com
 +home https://github.com/objectionary/eo-threads
 +junit
@@ -91,3 +92,32 @@
         nop
     $.equal-to
       "The 1th argument of 'int.div' is invalid: division by zero is infinity"
+
+[] > parallel-sleeping
+  thread > t1
+    sleep 200
+  thread > t2
+    sleep 200
+  seq > @
+    QQ.sys.call > start
+      "gettimeofday"
+    t1.start
+    t2.start
+    t1.join
+    t2.join
+    QQ.sys.call > finish
+      "gettimeofday"
+    lte.
+      minus.
+        finish
+        start
+      300
+
+[] > get-time-of-day-test
+  if. > @
+    QQ.sys.uname.is-windows
+    nop
+    assert-that
+      QQ.sys.call
+        "gettimeofday"
+      $.greater-than 0

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -113,5 +113,5 @@
         call "gettimeofday"
       lt.
         finish.minus start
-        300000
+        390000
     $.equal-to TRUE


### PR DESCRIPTION
Solve #16 
I added test proves `threads` dataizes `slow` in parallel.
It's not possible to use `$less-than` here becase of [this](https://github.com/objectionary/eo-hamcrest/issues/128)
Note `"gettimeofday"` returns `nanos`