### PR TITLE
24 ex interrupted handling

### DIFF
--- a/src/main/java/EOorg/EOeolang/EOthreads/DataizingThread.java
+++ b/src/main/java/EOorg/EOeolang/EOthreads/DataizingThread.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExAbstract;
+import org.eolang.ExFailure;
+import org.eolang.ExInterrupted;
 import org.eolang.Phi;
 
 /**
@@ -83,6 +85,11 @@ final class DataizingThread extends Thread {
     public void run() {
         try {
             this.computed = new Data.ToPhi(new Dataized(this.thread.attr("slow").get()).take());
+        } catch (final ExInterrupted ex) {
+            this.failure = new ExFailure(
+                "Cannot give dataized \"slow\" since thread \"%s\" was stopped",
+                this.thread.toString()
+            );
         } catch (final ExAbstract ex) {
             this.failure = ex;
         }

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -22,6 +22,7 @@
 
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.sys.call
++alias org.eolang.txt.text
 +alias org.eolang.threads.thread
 +alias org.eolang.threads.sleep
 +architect 28lev11@gmail.com
@@ -138,3 +139,30 @@
           finish.minus start
           600000
       $.equal-to TRUE
+
+[] > thread-stops
+  thread > t
+    sleep 1000
+  assert-that > @
+    seq
+      t.start
+      t.stop
+      try
+        []
+          t.join > @
+        [e]
+          slice. > @
+            text
+              e
+            0
+            20
+        nop
+    $.equal-to
+      "Cannot give dataized"
+
+# @todo #14:60min Impplement test
+#  that stoppes a thread and check
+#  if the thread is running. We need
+#  is-running attribute for this
+[] > is-running-after-stop
+  nop > @

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -160,6 +160,6 @@
 # @todo #14:60min Impplement test
 #  that stops a thread and checks
 #  if the thread is running. We need
-#  is-running attribute for this
+#  is-running attribute to use it
 [] > is-running-after-stop
   nop > @

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -22,7 +22,6 @@
 
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.sys.call
-+alias org.eolang.txt.text
 +alias org.eolang.threads.thread
 +alias org.eolang.threads.sleep
 +architect 28lev11@gmail.com
@@ -151,9 +150,7 @@
         []
           t.join > @
         [e]
-          slice. > @
-            text
-              e
+          e.slice > @
             0
             20
         nop
@@ -161,7 +158,7 @@
       "Cannot give dataized"
 
 # @todo #14:60min Impplement test
-#  that stoppes a thread and check
+#  that stops a thread and checks
 #  if the thread is running. We need
 #  is-running attribute for this
 [] > is-running-after-stop


### PR DESCRIPTION
Solving #24 
Now we can use `thread.stop`.
After `thread.stop` calling `thread.join` throws exception because it can't return computed `slow`