### PR TITLE
Replaced test meta from +junit to +tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SOFTWARE.
   <packaging>jar</packaging>
   <name>eo-threads</name>
   <properties>
-    <eolang.version>0.28.10</eolang.version>
+    <eolang.version>0.29.4</eolang.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,10 @@
   "extends": [
     "config:base"
   ],
-  "ignoreDeps": ["maven-compiler-plugin"]
+  "packageRules": [
+    {
+      "matchPackageNames": ["maven-compiler-plugin"],
+      "allowedVersions": "3.8.1"
+    }
+  ]
 }

--- a/src/test/eo/org/eolang/threads/mutex-test.eo
+++ b/src/test/eo/org/eolang/threads/mutex-test.eo
@@ -28,8 +28,8 @@
 +alias org.eolang.collections.list
 +architect 28lev11@gmail.com
 +home https://github.com/objectionary/eo-threads
-+junit
 +package org.eolang.threads
++tests
 +version 0.0.0
 
 [] > acquire-release

--- a/src/test/eo/org/eolang/threads/sleep-test.eo
+++ b/src/test/eo/org/eolang/threads/sleep-test.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.threads.sleep
 +architect 28lev11@gmail.com
 +home https://github.com/objectionary/eo-threads
-+junit
 +package org.eolang.threads
++tests
 +version 0.0.0
 
 [] > sleep-returns-true

--- a/src/test/eo/org/eolang/threads/thread-test.eo
+++ b/src/test/eo/org/eolang/threads/thread-test.eo
@@ -26,8 +26,8 @@
 +alias org.eolang.threads.sleep
 +architect 28lev11@gmail.com
 +home https://github.com/objectionary/eo-threads
-+junit
 +package org.eolang.threads
++tests
 +version 0.0.0
 
 [] > thread-returns-string


### PR DESCRIPTION
Closes: #83 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates package and version information and removes JUnit dependency from the `org.eolang.threads` package. 

### Detailed summary
- Updates package and version information for `org.eolang.threads` package
- Removes JUnit dependency from `org.eolang.threads` package
- Adds `tests` package to `org.eolang.threads` package
- Updates `eolang.version` property in `pom.xml` from `0.28.10` to `0.29.4`
- Adds `packageRules` to `renovate.json` to allow only version `3.8.1` of `maven-compiler-plugin`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->