### PR TITLE
increased stack size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@ SOFTWARE.
     <eolang.version>0.29.4</eolang.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <stack-size>256M</stack-size>
   </properties>
   <description>EO objects for manipulations with threads.</description>
   <url>https://github.com/objectionary/eo-threads</url>
@@ -113,6 +114,13 @@ SOFTWARE.
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration combine.self="override"/>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Xss${stack-size}</argLine>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.eolang</groupId>


### PR DESCRIPTION
Closes: #77 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new configuration to the `maven-surefire-plugin` in the `pom.xml` file to set the stack size for tests.

### Detailed summary
- Added `stack-size` property to `pom.xml`
- Added `maven-surefire-plugin` with `argLine` configuration to set stack size for tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->