### PR TITLE
Manually update eolang.version to v0.33.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SOFTWARE.
   <packaging>jar</packaging>
   <name>eo-threads</name>
   <properties>
-    <eolang.version>0.32.0</eolang.version>
+    <eolang.version>0.33.0</eolang.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <stack-size>256M</stack-size>


### PR DESCRIPTION
Closes #99 

<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `eolang.version` property in the `pom.xml` file from `0.32.0` to `0.33.0`.

### Detailed summary
- Updated `eolang.version` property from `0.32.0` to `0.33.0` in `pom.xml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->